### PR TITLE
Fix failed steps on goreleaser snapshot builds

### DIFF
--- a/.github/workflows/go-build-release.yml
+++ b/.github/workflows/go-build-release.yml
@@ -137,6 +137,7 @@ jobs:
 
       - name: Process GoReleaser output
         id: process_goreleaser_output
+        if: ${{ !contains(steps.snapshot_flags.outputs.flags, '--snapshot') }}
         run: |
           echo "const fs = require('fs');" > process.js
           echo 'const artifacts = ${{ steps.goreleaser.outputs.artifacts }}' >> process.js
@@ -152,7 +153,7 @@ jobs:
           subject-path: ${{ inputs.attestation-binary-path }}
 
       - name: Generate build provenance for container
-        if: ${{ steps.process_goreleaser_output.outputs.digest != '' && steps.process_goreleaser_output.outputs.digest != 'undefined' }}
+        if: ${{ !contains(steps.snapshot_flags.outputs.flags, '--snapshot') && steps.process_goreleaser_output.outputs.digest != '' && steps.process_goreleaser_output.outputs.digest != 'undefined' }}
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ inputs.registry-name }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use major version tags for stability:
 # For reusable workflows
 jobs:
   release:
-    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.1
+    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.2
 ```
 
 Pin a commit SHA internally for maximum supply‑chain safety if desired.
@@ -49,7 +49,7 @@ on:
 
 jobs:
   release:
-    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.1
+    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.2
     with:
       pre-build-commands: |
         go install github.com/swaggo/swag/cmd/swag@latest


### PR DESCRIPTION
Fixes https://github.com/OpenCHAMI/github-actions/pull/2

During snapshot builds we wont have a digest output from goreleaser so the `Process GoReleaser output` and `Generate build provenance for container` steps need to be skipped. 

Succesful [snapshot build ](https://github.com/taylorludwig/openchami-cloud-init/actions/runs/17138003507/job/48618704401) with skipped steps
<img width="472" height="168" alt="image" src="https://github.com/user-attachments/assets/8946cb2d-5aa6-46dc-8c9d-8dfd721e2b6e" />

Succsful [tag build](https://github.com/taylorludwig/openchami-cloud-init/actions/runs/17138054753/job/48618873508) with all steps 
<img width="411" height="158" alt="image" src="https://github.com/user-attachments/assets/b85b4a0d-d5f0-46cd-8ce1-9b4f1d41ad70" />

