### PR TITLE
Update go-build-release step names

### DIFF
--- a/.github/workflows/go-build-release.yml
+++ b/.github/workflows/go-build-release.yml
@@ -1,4 +1,5 @@
-name: Go Build and Release with GoReleaser
+name: GoReleaser
+run-name: GoReleaser ${{ (inputs.snapshot == 'true' || (inputs.snapshot != 'false' && !startsWith(github.ref, 'refs/tags/v'))) && 'Snapshot' || 'Release' }}
 
 on:
   workflow_call:
@@ -61,7 +62,8 @@ on:
 permissions: write-all # Necessary for the generate-build-provenance action with containers
 
 jobs:
-  build_and_release:
+  goreleaser:
+    name: GoReleaser ${{ (inputs.snapshot == 'true' || (inputs.snapshot != 'false' && !startsWith(github.ref, 'refs/tags/v'))) && 'Snapshot' || 'Release' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
@@ -126,14 +128,14 @@ jobs:
             fi
           fi
 
-      - name: Release with GoReleaser
+      - name: GoReleaser ${{ inputs.goreleaser-args }} ${{ steps.snapshot_flags.outputs.flags }}
+        id: goreleaser
         uses: goreleaser/goreleaser-action@v6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           version: ${{ inputs.goreleaser-version }}
           args: ${{ inputs.goreleaser-args }} ${{ steps.snapshot_flags.outputs.flags }}
-        id: goreleaser
 
       - name: Process GoReleaser output
         id: process_goreleaser_output

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use major version tags for stability:
 # For reusable workflows
 jobs:
   release:
-    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.2
+    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.3
 ```
 
 Pin a commit SHA internally for maximum supply‑chain safety if desired.
@@ -38,7 +38,8 @@ Standardized GoReleaser workflow for building and releasing Go applications with
 
 **Usage:**
 ```yaml
-name: Release with goreleaser
+name: GoReleaser
+run-name: GoReleaser ${{ startsWith(github.ref, 'refs/tags/v') && 'Release' || 'Snapshot' }}
 
 on:
   workflow_dispatch:
@@ -48,8 +49,9 @@ on:
       - v*
 
 jobs:
-  release:
-    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.2
+  goreleaser:
+    name: GoReleaser ${{ startsWith(github.ref, 'refs/tags/v') && 'Release' || 'Snapshot' }}
+    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.3
     with:
       pre-build-commands: |
         go install github.com/swaggo/swag/cmd/swag@latest


### PR DESCRIPTION
When integrating with the power-control repo https://github.com/OpenCHAMI/power-control/pull/46

It was requested that the workflow and job names make it more clear when its a snapshot releave vs a real release. 

You can see in the PR's original way the names show up like: 
<img width="638" height="298" alt="image" src="https://github.com/user-attachments/assets/14bfd88e-638d-450e-a51b-e82a734cde54" />

Now with this change (and when the calling workflow is updated to maatch the example in the readme) it looks like: 
<img width="845" height="346" alt="image" src="https://github.com/user-attachments/assets/ae98b8af-2833-4bd3-bbc6-2abe5ab7b87a" />

So now the names will be `GoReleaser Snapshot|Release` 

Readme is updated to assume this is tagged as `v3.3` 