### PR TITLE
CGO_ENABLED should be a number

### DIFF
--- a/.github/workflows/go-build-release.yml
+++ b/.github/workflows/go-build-release.yml
@@ -22,8 +22,7 @@ on:
       cgo-enabled:
         description: 'Set CGO_ENABLED environment variable'
         required: false
-        type: string
-        default: ''
+        type: number
       additional-env-vars:
         description: 'Additional environment variables to set (KEY=value format, one per line)'
         required: false
@@ -116,7 +115,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Set CGO_ENABLED if specified
-        if: ${{ inputs.cgo-enabled != '' }}
+        if: ${{ inputs.cgo-enabled != null }}
         run: echo "CGO_ENABLED=${{ inputs.cgo-enabled }}" >> "$GITHUB_ENV"
 
       - name: Set additional environment variables


### PR DESCRIPTION
CGO_ENABLED should be 0 or 1, use number to constrain values.

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [ ] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [ ] **REUSE Compliance**:  
  - [ ] Each new/modified source file has SPDX copyright and license headers  
  - [ ] Any non-commentable files include a `<filename>.license` sidecar  
  - [ ] All referenced licenses are present in the `LICENSES/` directory  

### Description

The PCS CI is using this workflow. It has `cgo_enabled: true`, which mean CGO is disabled as `CGO_ENABLED` should `0` or `1`, "true" gets treated as disabled! 


### Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
