### PR TITLE
feat: remove snapshot image push

### DIFF
--- a/.github/workflows/go-build-release.yml
+++ b/.github/workflows/go-build-release.yml
@@ -186,23 +186,3 @@ jobs:
           subject-name: ${{ inputs.registry-name }}
           subject-digest: ${{ steps.process_goreleaser_output.outputs.digest }}
           push-to-registry: true
-
-      # Credit to the https://github.com/goreleaser/goreleaser/issues/2828#issuecomment-1311662146 workaround
-      # for nightly/snapshot builds being locked behind the paid version of goreleaser.
-      - name: List snapshot images
-        # types are hard vov https://github.com/actions/runner/issues/2238
-        if: true
-        run: |
-          short_sha=$(git rev-parse --short HEAD)
-          docker image ls --format "{{.Repository}}:{{.Tag}}" | \
-            grep -e "$GITHUB_REPOSITORY:.*${short_sha}.*" | \
-            paste -sd ' ' /dev/stdin > images
-      - name: Push snapshot images
-        if: true
-        run: |
-          xargs -d ' ' -I{} -n1 sh -c "docker push {}" < images
-      - name: Create and push manifest for :snapshot tag
-        if: true
-        run: |
-          docker manifest create "$GITHUB_REPOSITORY:snapshot" "$(cat images)"
-          docker manifest push "$GITHUB_REPOSITORY:snapshot"


### PR DESCRIPTION
Remove the snapshot image push workaround.

I added this, but AFAIK we're not actually using it. I checked through the first 7 results for https://github.com/search?q=org%3AOpenCHAMI+%22name%3A+Release+with+goreleaser%22&type=code and they're all triggering on tags and dispatch only.

We're _maybe_ using dispatch to trigger this and using those images, but I think that's not the case. If I'm wrong, we should reject this!

The alternate way to fix the linter complaints in https://github.com/OpenCHAMI/github-actions/pull/8 is to remove the `if: true` lines. IIRC I had those in place because I _wanted_ to pass a dispatch checkbox for "release this snapshot image", and couldn't because of the bug mentioned in the comment. Best guess is that I wanted to only add the Docker-based build shared workflow in that PR, but forgot to remove stuff I was trying during the hackathon.